### PR TITLE
Update ItemDetailsScreen.kt

### DIFF
--- a/app/src/main/java/com/example/inventory/ui/item/ItemDetailsScreen.kt
+++ b/app/src/main/java/com/example/inventory/ui/item/ItemDetailsScreen.kt
@@ -123,7 +123,7 @@ private fun ItemDetailsBody(
             onClick = onSellItem,
             modifier = Modifier.fillMaxWidth(),
             shape = MaterialTheme.shapes.small,
-            enabled = true
+            enabled = !itemDetailsUiState.outOfStock
         ) {
             Text(stringResource(R.string.sell))
         }


### PR DESCRIPTION
Save button to be disabled when outOfStock is true. 
Currently, the save button is enabled for any quantity.

Codelabs for "Read and update data with Room" does not add this step from Section (8). Implement sell item, step 13.
The starter branch also needs the update though it would be easier if the codelabs implemented the step instead.

Issue: https://github.com/google-developer-training/basic-android-kotlin-compose-training-inventory-app/issues/52

![image](https://github.com/google-developer-training/basic-android-kotlin-compose-training-inventory-app/assets/39038103/d6662408-409c-40b0-be8e-e48a5195176c)
